### PR TITLE
Use md5.Sum()

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -10,10 +10,8 @@ import (
 // CalcMD5Hash calculates hash value of the string input by MD5.
 // Remark: MD5 returns 128-bits value
 func CalcMD5Hash(str string) string {
-	hasher := md5.New()
-	hasher.Write([]byte(str))
-
-	return hex.EncodeToString(hasher.Sum(nil))
+	h := md5.Sum([]byte(str))
+	return hex.EncodeToString(h[:])
 }
 
 // DoubleHashing calculates hash value by double-hashing.


### PR DESCRIPTION
```go
package sketch

import (
	"fmt"
	"testing"
)

func BenchmarkCount(b *testing.B) {
	s := NewSketch()
	for i := 0; i < b.N; i++ {
		ss := fmt.Sprintf("%09d", i)
		s.Add(ss)
		s.Count(ss)
	}
}
```

Before:
goos: windows
goarch: amd64
pkg: github.com/cipepser/go-sketch/sketch
BenchmarkCount-4   	  230755	      5149 ns/op
BenchmarkCount-4   	  244882	      5121 ns/op
BenchmarkCount-4   	  244882	      5174 ns/op
BenchmarkCount-4   	  235280	      5109 ns/op
BenchmarkCount-4   	  226401	      5018 ns/op
PASS
ok  	github.com/cipepser/go-sketch/sketch	6.399s

After:
goos: windows
goarch: amd64
pkg: github.com/cipepser/go-sketch/sketch
BenchmarkCount-4   	  235280	      4297 ns/op
BenchmarkCount-4   	  285697	      4365 ns/op
BenchmarkCount-4   	  279054	      4358 ns/op
BenchmarkCount-4   	  279054	      4304 ns/op
BenchmarkCount-4   	  285697	      4383 ns/op
PASS
ok  	github.com/cipepser/go-sketch/sketch	7.116s

name     old time/op  new time/op  delta
Count-4  5.11µs ± 2%  4.34µs ± 1%  -15.11%  (p=0.008 n=5+5)